### PR TITLE
Expose type helpers for custom components

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "devDependencies": {
     "rome": "^10.0.1",
     "turbo": "^1.6.3",
-    "typescript": "^4.8.2"
+    "typescript": "^4.9.3"
   }
 }

--- a/packages/react-trello-ts/package.json
+++ b/packages/react-trello-ts/package.json
@@ -57,6 +57,7 @@
     "@storybook/addon-info": "5.3.21",
     "@storybook/addon-options": "5.3.21",
     "@storybook/addon-storyshots": "6.5.10",
+    "@storybook/builder-webpack5": "^6.5.13",
     "@storybook/cli": "6.5.10",
     "@storybook/core-events": "^5.1.3",
     "@storybook/manager-webpack5": "^6.5.10",
@@ -90,7 +91,7 @@
     "styled-components": "^5",
     "ts-jest": "^27",
     "tsup": "^6.2.3",
-    "typescript": "^4.8.2",
+    "typescript": "^4.9.3",
     "webpack": "*"
   },
   "peerDependencies": {

--- a/packages/react-trello-ts/src/components/AddCardLink.tsx
+++ b/packages/react-trello-ts/src/components/AddCardLink.tsx
@@ -1,11 +1,33 @@
-import React, { FC, HTMLAttributes, PropsWithChildren } from "react";
-import { AddCardLink as _AddCardLink } from "../styles/Base";
-import { createTranslate } from "..";
+import React, {FC, HTMLAttributes, PropsWithChildren} from 'react'
+import {AddCardLink as _AddCardLink} from '../styles/Base'
+import {createTranslate} from '..'
 
-interface AddCardLinkProps extends HTMLAttributes<HTMLAnchorElement> {
-	t: typeof createTranslate;
+/**
+ * AddCardLink component type
+ *
+ * Pass in a type to the optional generic to add custom properties
+ *
+ * @example
+ *
+ * type Props = {
+ * 	customProperty: string;
+ * }
+ *
+ * const CustomAddCardLink: AddCardLinkComponent<Props> = ({ customProperty, ...props }) => {
+ * 	return (
+ *		...
+ *		{customProperty}
+ *		...
+ * 	)
+ * }
+ */
+export type AddCardLinkComponent<TCustomAddCardLinkProps extends {} = {}> = FC<
+  PropsWithChildren<AddCardLinkProps & TCustomAddCardLinkProps>
+>
+
+interface AddCardLinkProps extends HTMLAttributes<HTMLAnchorElement | HTMLButtonElement> {
+  t: typeof createTranslate
 }
-export const AddCardLink: FC<PropsWithChildren<AddCardLinkProps>> = ({
-	onClick,
-	t,
-}) => <_AddCardLink onClick={onClick}>{t("Click to add card")}</_AddCardLink>;
+export const AddCardLink: FC<PropsWithChildren<AddCardLinkProps>> = ({onClick, t}) => (
+  <_AddCardLink onClick={onClick}>{t('Click to add card')}</_AddCardLink>
+)

--- a/packages/react-trello-ts/src/components/Card.tsx
+++ b/packages/react-trello-ts/src/components/Card.tsx
@@ -20,6 +20,29 @@ import { createTranslate } from "..";
 import { Card as ICard } from "../types/Board";
 import { StyledComponent } from "styled-components";
 
+/**
+ * Card component type
+ *
+ * Pass in a type to the optional generic to add custom properties to the card
+ *
+ * @example
+ *
+ * type CustomCardProps = {
+ * 	dueOn: string;
+ * }
+ *
+ * const CustomCard: CardComponent<CustomCardProps> = ({ dueOn, ...props }) => {
+ * 	return (
+ * 		<Card {...props}>
+ * 			<Detail>{dueOn}</Detail>
+ * 		</Card>
+ * 	)
+ * }
+ */
+export type CardComponent<TCustomCardProps extends {} = {}> = FC<
+	PropsWithChildren<CardProps & TCustomCardProps>
+>;
+
 export type CardProps = {
 	showDeleteButton?: boolean;
 	onDelete?: () => void;
@@ -37,9 +60,9 @@ export type CardProps = {
 	cardDraggable?: boolean;
 	editable?: boolean;
 	t: typeof createTranslate;
-} & { [key: string]: any };
+};
 
-export const Card: FC<PropsWithChildren<CardProps>> = ({
+export const Card: CardComponent = ({
 	onDelete,
 	onChange,
 	id,

--- a/packages/react-trello-ts/src/components/Lane/LaneFooter.tsx
+++ b/packages/react-trello-ts/src/components/Lane/LaneFooter.tsx
@@ -3,14 +3,17 @@ import React, { FC, HTMLAttributes, PropsWithChildren } from "react";
 import { LaneFooter as _LaneFooter } from "../../styles/Base";
 import { CollapseBtn, ExpandBtn } from "../../styles/Elements";
 
+export type LaneFooterComponent = FC<PropsWithChildren<LaneFooterProps>>;
+
 interface LaneFooterProps extends HTMLAttributes<HTMLDivElement> {
 	collapsed?: boolean;
 }
-export const LaneFooter: FC<PropsWithChildren<LaneFooterProps>> = ({
+export const LaneFooter: LaneFooterComponent = ({
 	onClick,
+	onKeyDown,
 	collapsed,
 }) => (
-	<_LaneFooter onClick={onClick}>
+	<_LaneFooter onClick={onClick} onKeyDown={onKeyDown}>
 		{collapsed ? <ExpandBtn /> : <CollapseBtn />}
 	</_LaneFooter>
 );

--- a/packages/react-trello-ts/stories/CustomAddCardLink.story.tsx
+++ b/packages/react-trello-ts/stories/CustomAddCardLink.story.tsx
@@ -1,20 +1,15 @@
-import React from "react";
-import { storiesOf } from "@storybook/react";
+import React from 'react'
+import {storiesOf} from '@storybook/react'
 
-import Board from "../src";
+import Board from '../src'
+import {AddCardLinkComponent} from 'rt/components/AddCardLink'
 
-const data = require("./data/collapsible.json");
+const data = require('./data/collapsible.json')
 
-const CustomAddCardLink = ({ onClick, t }) => (
-	<button onClick={onClick}>{t("Click to add card")}</button>
-);
+const CustomAddCardLink: AddCardLinkComponent = ({onClick, t}) => (
+  <button onClick={onClick}>{t('Click to add card')}</button>
+)
 
-storiesOf("Custom Components", module).add("AddCardLink", () => {
-	return (
-		<Board
-			data={data}
-			editable={true}
-			components={{ AddCardLink: CustomAddCardLink }}
-		/>
-	);
-});
+storiesOf('Custom Components', module).add('AddCardLink', () => {
+  return <Board data={data} editable={true} components={{AddCardLink: CustomAddCardLink}} />
+})

--- a/packages/react-trello-ts/stories/CustomCard.story.tsx
+++ b/packages/react-trello-ts/stories/CustomCard.story.tsx
@@ -1,12 +1,21 @@
-import React from "react";
+import React, { CSSProperties } from "react";
 import { storiesOf } from "@storybook/react";
 import { MovableCardWrapper } from "rt/styles/Base";
 import { DeleteButton } from "./../src/widgets/DeleteButton";
 import Board from "../src";
 import { Tag } from "rt/components/Card/Tag";
 import { BoardData } from "rt/types/Board";
+import { CardComponent } from "rt/components/Card";
 
-const CustomCard = ({
+const CustomCard: CardComponent<{
+	name: string;
+	cardStyle: CSSProperties;
+	body: string;
+	dueOn: string;
+	cardColor: CSSProperties["color"];
+	subTitle: string;
+	escalationText: string;
+}> = ({
 	onClick,
 	className,
 	name,

--- a/packages/react-trello-ts/stories/CustomLaneFooter.story.tsx
+++ b/packages/react-trello-ts/stories/CustomLaneFooter.story.tsx
@@ -2,11 +2,12 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 
 import Board from "../src";
+import { LaneFooterComponent } from "rt/components/Lane/LaneFooter";
 
-const data = require("./data/collapsible.json");
+import data from "./data/collapsible.json";
 
-const LaneFooter = ({ onClick, collapsed }) => (
-	<div onClick={onClick} onKeyDown={onClick}>
+const LaneFooter: LaneFooterComponent = ({ onClick, onKeyDown, collapsed }) => (
+	<div onClick={onClick} onKeyDown={onKeyDown}>
 		{collapsed ? "click to expand" : "click to collapse"}
 	</div>
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,11 @@ importers:
     specifiers:
       rome: ^10.0.1
       turbo: ^1.6.3
-      typescript: ^4.8.2
+      typescript: ^4.9.3
     devDependencies:
       rome: 10.0.1
       turbo: 1.6.3
-      typescript: 4.8.4
+      typescript: 4.9.3
 
   apps/cypress-testing:
     specifiers:
@@ -52,6 +52,7 @@ importers:
       '@storybook/addon-info': 5.3.21
       '@storybook/addon-options': 5.3.21
       '@storybook/addon-storyshots': 6.5.10
+      '@storybook/builder-webpack5': ^6.5.13
       '@storybook/cli': 6.5.10
       '@storybook/core-events': ^5.1.3
       '@storybook/manager-webpack5': ^6.5.10
@@ -92,7 +93,7 @@ importers:
       trello-smooth-dnd: 1.0.0
       ts-jest: ^27
       tsup: ^6.2.3
-      typescript: ^4.8.2
+      typescript: ^4.9.3
       uuid: ^9
       webpack: '*'
       zustand: ^4.1.1
@@ -117,11 +118,12 @@ importers:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.19.6
       '@storybook/addon-info': 5.3.21_oxitegypfa7ixs7q4tmuwofsju
       '@storybook/addon-options': 5.3.21_a4hz2i5vbrrfb3gdfx7xmkvtqq
-      '@storybook/addon-storyshots': 6.5.10_n4dynuwyelorgkqdm6xdv6nn3q
-      '@storybook/cli': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/addon-storyshots': 6.5.10_nxc7vo5ivcwqxtpw3z2z3kicwy
+      '@storybook/builder-webpack5': 6.5.13_lpaunfundvhsawddnxa2u6vj2i
+      '@storybook/cli': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/core-events': 5.3.21
-      '@storybook/manager-webpack5': 6.5.12_zvdcumho7mqj3lfknr2wnpofbm
-      '@storybook/react': 6.5.10_crqyzl53zvoogn5jtj5fo5ztaq
+      '@storybook/manager-webpack5': 6.5.12_lpaunfundvhsawddnxa2u6vj2i
+      '@storybook/react': 6.5.10_dnbb5qcebrpunavuaqymrwxhmu
       '@testing-library/react': 12.1.5_wcqkhtmu7mswc6yz4uyexck3ty
       '@types/jest': 27.5.2
       '@types/lodash': 4.14.186
@@ -149,9 +151,9 @@ importers:
       require-from-string: 2.0.2
       semantic-release: 17.4.7
       styled-components: 5.3.6_a7b7i3ycivfl5nfe5xs34epzw4
-      ts-jest: 27.1.5_wllvn5ev7s34rczlryjnunwcxu
-      tsup: 6.3.0_typescript@4.8.4
-      typescript: 4.8.4
+      ts-jest: 27.1.5_hkzu5mxcd5jsil5nsffofi7n7u
+      tsup: 6.3.0_typescript@4.9.3
+      typescript: 4.9.3
       webpack: 5.74.0
 
 packages:
@@ -2654,7 +2656,7 @@ packages:
       - regenerator-runtime
     dev: true
 
-  /@storybook/addon-storyshots/6.5.10_n4dynuwyelorgkqdm6xdv6nn3q:
+  /@storybook/addon-storyshots/6.5.10_nxc7vo5ivcwqxtpw3z2z3kicwy:
     resolution: {integrity: sha512-26vYmjcUupgsfCkfM3oGpbiyxH8bsdArPngwDdC8PRR7+wuhdKtFtQMYE/FcPQZTiF2IvvYdUZ7smPUmL732Yg==}
     peerDependencies:
       '@angular/core': '>=6.0.0'
@@ -2709,11 +2711,11 @@ packages:
       '@storybook/addons': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/babel-plugin-require-context-hook': 1.0.1
       '@storybook/client-api': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core': 6.5.10_uqtyzneeudcfmmjorcoxo4kotu
-      '@storybook/core-client': 6.5.10_plmdyubmb7xm6euvqu3qohl7ea
-      '@storybook/core-common': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/core': 6.5.10_oqlzm5bgprcyy7hdmsd7yzvm34
+      '@storybook/core-client': 6.5.10_zmcfsz5vzopt24dcvkwti4umve
+      '@storybook/core-common': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/react': 6.5.10_crqyzl53zvoogn5jtj5fo5ztaq
+      '@storybook/react': 6.5.10_dnbb5qcebrpunavuaqymrwxhmu
       '@types/glob': 7.2.0
       '@types/jest': 26.0.24
       '@types/jest-specific-snapshot': 0.5.6
@@ -2797,6 +2799,27 @@ packages:
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/router': 6.5.12_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/theming': 6.5.12_wcqkhtmu7mswc6yz4uyexck3ty
+      '@types/webpack-env': 1.18.0
+      core-js: 3.25.5
+      global: 4.4.0
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      regenerator-runtime: 0.13.10
+    dev: true
+
+  /@storybook/addons/6.5.13_wcqkhtmu7mswc6yz4uyexck3ty:
+    resolution: {integrity: sha512-18CqzNnrGMfeZtiKz+R/3rHtSNnfNwz6y6prIQIbWseK16jY8ELTfIFGviwO5V2OqpbHDQi5+xQQ63QAIb89YA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/api': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/channels': 6.5.13
+      '@storybook/client-logger': 6.5.13
+      '@storybook/core-events': 6.5.13
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/router': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/theming': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
       '@types/webpack-env': 1.18.0
       core-js: 3.25.5
       global: 4.4.0
@@ -2889,11 +2912,38 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
+  /@storybook/api/6.5.13_wcqkhtmu7mswc6yz4uyexck3ty:
+    resolution: {integrity: sha512-xVSmB7/IuFd6G7eiJjbI2MuS7SZunoUM6d+YCWpjiehfMeX47MXt1gZtOwFrgJC1ShZlefXFahq/dvxwtmWs+w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/channels': 6.5.13
+      '@storybook/client-logger': 6.5.13
+      '@storybook/core-events': 6.5.13
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/router': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/semver': 7.3.2
+      '@storybook/theming': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      core-js: 3.25.5
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      regenerator-runtime: 0.13.10
+      store2: 2.14.2
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: true
+
   /@storybook/babel-plugin-require-context-hook/1.0.1:
     resolution: {integrity: sha512-WM4vjgSVi8epvGiYfru7BtC3f0tGwNs7QK3Uc4xQn4t5hHQvISnCqbNrHdDYmNW56Do+bBztE8SwP6NGUvd7ww==}
     dev: true
 
-  /@storybook/builder-webpack4/6.5.10_zvdcumho7mqj3lfknr2wnpofbm:
+  /@storybook/builder-webpack4/6.5.10_lpaunfundvhsawddnxa2u6vj2i:
     resolution: {integrity: sha512-AoKjsCNoQQoZXYwBDxO8s+yVEd5FjBJAaysEuUTHq2fb81jwLrGcEOo6hjw4jqfugZQIzYUEjPazlvubS78zpw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -2911,7 +2961,7 @@ packages:
       '@storybook/client-api': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/client-logger': 6.5.10
       '@storybook/components': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-common': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/core-common': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/core-events': 6.5.10
       '@storybook/node-logger': 6.5.10
       '@storybook/preview-web': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
@@ -2929,12 +2979,12 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_lasgyenclx45ngbljrbo537mpe
+      fork-ts-checker-webpack-plugin: 4.1.6_4saukclyqastvrycwsozxxbldi
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       global: 4.4.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@4.8.4
+      pnp-webpack-plugin: 1.6.4_typescript@4.9.3
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
@@ -2945,7 +2995,7 @@ packages:
       style-loader: 1.3.0_webpack@4.46.0
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.8.4
+      typescript: 4.9.3
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -2957,6 +3007,68 @@ packages:
       - bluebird
       - eslint
       - supports-color
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: true
+
+  /@storybook/builder-webpack5/6.5.13_lpaunfundvhsawddnxa2u6vj2i:
+    resolution: {integrity: sha512-juNH31ZljWbaoBD6Yx2/iQ4G66UBkwq+cFUqLzgVROKMXmYaT0AJYbfyY8CgGqcXkc+sqNA63yWaLWd8/K9vTg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.19.6
+      '@storybook/addons': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/api': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/channel-postmessage': 6.5.13
+      '@storybook/channels': 6.5.13
+      '@storybook/client-api': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/client-logger': 6.5.13
+      '@storybook/components': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/core-common': 6.5.13_lpaunfundvhsawddnxa2u6vj2i
+      '@storybook/core-events': 6.5.13
+      '@storybook/node-logger': 6.5.13
+      '@storybook/preview-web': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/router': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/semver': 7.3.2
+      '@storybook/store': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/theming': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@types/node': 16.11.68
+      babel-loader: 8.2.5_6zc4kxld457avlfyhj3lzsljlm
+      babel-plugin-named-exports-order: 0.0.2
+      browser-assert: 1.2.1
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      core-js: 3.25.5
+      css-loader: 5.2.7_webpack@5.74.0
+      fork-ts-checker-webpack-plugin: 6.5.2_ioost42n2pkm3q6vbnx4ypyu7a
+      glob: 7.2.3
+      glob-promise: 3.4.0_glob@7.2.3
+      html-webpack-plugin: 5.5.0_webpack@5.74.0
+      path-browserify: 1.0.1
+      process: 0.11.10
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      stable: 0.1.8
+      style-loader: 2.0.0_webpack@5.74.0
+      terser-webpack-plugin: 5.3.6_webpack@5.74.0
+      ts-dedent: 2.2.0
+      typescript: 4.9.3
+      util-deprecate: 1.0.2
+      webpack: 5.74.0
+      webpack-dev-middleware: 4.3.0_webpack@5.74.0
+      webpack-hot-middleware: 2.25.2
+      webpack-virtual-modules: 0.4.5
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - eslint
+      - supports-color
+      - uglify-js
       - vue-template-compiler
       - webpack-cli
       - webpack-command
@@ -2980,6 +3092,18 @@ packages:
       '@storybook/channels': 6.5.12
       '@storybook/client-logger': 6.5.12
       '@storybook/core-events': 6.5.12
+      core-js: 3.25.5
+      global: 4.4.0
+      qs: 6.11.0
+      telejson: 6.0.8
+    dev: true
+
+  /@storybook/channel-postmessage/6.5.13:
+    resolution: {integrity: sha512-R79MBs0mQ7TV8M/a6x/SiTRyvZBidDfMEEthG7Cyo9p35JYiKOhj2535zhW4qlVMESBu95pwKYBibTjASoStPw==}
+    dependencies:
+      '@storybook/channels': 6.5.13
+      '@storybook/client-logger': 6.5.13
+      '@storybook/core-events': 6.5.13
       core-js: 3.25.5
       global: 4.4.0
       qs: 6.11.0
@@ -3028,18 +3152,26 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/cli/6.5.10_zvdcumho7mqj3lfknr2wnpofbm:
+  /@storybook/channels/6.5.13:
+    resolution: {integrity: sha512-sGYSilE30bz0jG+HdHnkv0B4XkAv2hP+KRZr4xmnv+MOOQpRnZpJ5Z3HVU16s17cj/83NWihKj6BuKcEVzyilg==}
+    dependencies:
+      core-js: 3.25.5
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: true
+
+  /@storybook/cli/6.5.10_lpaunfundvhsawddnxa2u6vj2i:
     resolution: {integrity: sha512-avxlWVaxMasP4svsYaJ6ELfrcP3SKaIJeFbiu688kQCCX+7pOUOaWPXfiScNpuoQ8wdghcwyZzRkhcV873rHHA==}
     hasBin: true
     dependencies:
       '@babel/core': 7.19.6
       '@babel/preset-env': 7.19.4_@babel+core@7.19.6
       '@storybook/codemod': 6.5.10_@babel+preset-env@7.19.4
-      '@storybook/core-common': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/core-common': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/csf-tools': 6.5.10
       '@storybook/node-logger': 6.5.10
       '@storybook/semver': 7.3.2
-      '@storybook/telemetry': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/telemetry': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
       boxen: 5.1.2
       chalk: 4.1.2
       commander: 6.2.1
@@ -3136,6 +3268,36 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
+  /@storybook/client-api/6.5.13_wcqkhtmu7mswc6yz4uyexck3ty:
+    resolution: {integrity: sha512-uH1mAWbidPiuuTdMUVEiuaNOfrYXm+9QLSP1MMYTKULqEOZI5MSOGkEDqRfVWxbYv/iWBOPTQ+OM9TQ6ecYacg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/addons': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/channel-postmessage': 6.5.13
+      '@storybook/channels': 6.5.13
+      '@storybook/client-logger': 6.5.13
+      '@storybook/core-events': 6.5.13
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/store': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@types/qs': 6.9.7
+      '@types/webpack-env': 1.18.0
+      core-js: 3.25.5
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      qs: 6.11.0
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      regenerator-runtime: 0.13.10
+      store2: 2.14.2
+      synchronous-promise: 2.0.16
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: true
+
   /@storybook/client-logger/5.3.21:
     resolution: {integrity: sha512-OzQkwpZ5SK9cXD9Mv6lxPGPot+hSZvnkEW12kpt1AHfJz4ET26YTDOI3oetPsjfRJo6qYLeQX8+wF7rklfXbzA==}
     dependencies:
@@ -3151,6 +3313,13 @@ packages:
 
   /@storybook/client-logger/6.5.12:
     resolution: {integrity: sha512-IrkMr5KZcudX935/C2balFbxLHhkvQnJ78rbVThHDVckQ7l3oIXTh66IMzldeOabVFDZEMiW8AWuGEYof+JtLw==}
+    dependencies:
+      core-js: 3.25.5
+      global: 4.4.0
+    dev: true
+
+  /@storybook/client-logger/6.5.13:
+    resolution: {integrity: sha512-F2SMW3LWFGXLm2ENTwTitrLWJgmMXRf3CWQXdN2EbkNCIBHy5Zcbt+91K4OX8e2e5h9gjGfrdYbyYDYOoUCEfA==}
     dependencies:
       core-js: 3.25.5
       global: 4.4.0
@@ -3245,44 +3414,25 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/core-client/6.5.10_plmdyubmb7xm6euvqu3qohl7ea:
-    resolution: {integrity: sha512-THsIjNrOrampTl0Lgfjvfjk1JnktKb4CQLOM80KpQb4cjDqorBjJmErzUkUQ2y3fXvrDmQ/kUREkShET4XEdtA==}
+  /@storybook/components/6.5.13_wcqkhtmu7mswc6yz4uyexck3ty:
+    resolution: {integrity: sha512-6Hhx70JK5pGfKCkqMU4yq/BBH+vRTmzj7tZKfPwba+f8VmTMoOr/2ysTQFRtXryiHB6Z15xBYgfq5x2pIwQzLQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
     dependencies:
-      '@storybook/addons': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/channel-postmessage': 6.5.10
-      '@storybook/channel-websocket': 6.5.10
-      '@storybook/client-api': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/client-logger': 6.5.10
-      '@storybook/core-events': 6.5.10
+      '@storybook/client-logger': 6.5.13
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/preview-web': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/store': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/ui': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      airbnb-js-shims: 2.2.1
-      ansi-to-html: 0.6.15
+      '@storybook/theming': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
       core-js: 3.25.5
-      global: 4.4.0
-      lodash: 4.17.21
+      memoizerific: 1.11.3
       qs: 6.11.0
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
       regenerator-runtime: 0.13.10
-      ts-dedent: 2.2.0
-      typescript: 4.8.4
-      unfetch: 4.2.0
       util-deprecate: 1.0.2
-      webpack: 5.74.0
     dev: true
 
-  /@storybook/core-client/6.5.10_vvswzvegta47ikremfl73qk64u:
+  /@storybook/core-client/6.5.10_5rrtmghzrfkli2obki6uk67fly:
     resolution: {integrity: sha512-THsIjNrOrampTl0Lgfjvfjk1JnktKb4CQLOM80KpQb4cjDqorBjJmErzUkUQ2y3fXvrDmQ/kUREkShET4XEdtA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3313,13 +3463,50 @@ packages:
       react-dom: 16.14.0_react@16.14.0
       regenerator-runtime: 0.13.10
       ts-dedent: 2.2.0
-      typescript: 4.8.4
+      typescript: 4.9.3
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
     dev: true
 
-  /@storybook/core-client/6.5.12_plmdyubmb7xm6euvqu3qohl7ea:
+  /@storybook/core-client/6.5.10_zmcfsz5vzopt24dcvkwti4umve:
+    resolution: {integrity: sha512-THsIjNrOrampTl0Lgfjvfjk1JnktKb4CQLOM80KpQb4cjDqorBjJmErzUkUQ2y3fXvrDmQ/kUREkShET4XEdtA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      typescript: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@storybook/addons': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/channel-postmessage': 6.5.10
+      '@storybook/channel-websocket': 6.5.10
+      '@storybook/client-api': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/client-logger': 6.5.10
+      '@storybook/core-events': 6.5.10
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/preview-web': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/store': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/ui': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
+      airbnb-js-shims: 2.2.1
+      ansi-to-html: 0.6.15
+      core-js: 3.25.5
+      global: 4.4.0
+      lodash: 4.17.21
+      qs: 6.11.0
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      regenerator-runtime: 0.13.10
+      ts-dedent: 2.2.0
+      typescript: 4.9.3
+      unfetch: 4.2.0
+      util-deprecate: 1.0.2
+      webpack: 5.74.0
+    dev: true
+
+  /@storybook/core-client/6.5.12_zmcfsz5vzopt24dcvkwti4umve:
     resolution: {integrity: sha512-jyAd0ud6zO+flpLv0lEHbbt1Bv9Ms225M6WTQLrfe7kN/7j1pVKZEoeVCLZwkJUtSKcNiWQxZbS15h31pcYwqg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3350,13 +3537,13 @@ packages:
       react-dom: 16.14.0_react@16.14.0
       regenerator-runtime: 0.13.10
       ts-dedent: 2.2.0
-      typescript: 4.8.4
+      typescript: 4.9.3
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 5.74.0
     dev: true
 
-  /@storybook/core-common/6.5.10_zvdcumho7mqj3lfknr2wnpofbm:
+  /@storybook/core-common/6.5.10_lpaunfundvhsawddnxa2u6vj2i:
     resolution: {integrity: sha512-Bx+VKkfWdrAmD8T51Sjq/mMhRaiapBHcpG4cU5bc3DMbg+LF2/yrgqv/cjVu+m5gHAzYCac5D7gqzBgvG7Myww==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3400,7 +3587,7 @@ packages:
       express: 4.18.2
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_lasgyenclx45ngbljrbo537mpe
+      fork-ts-checker-webpack-plugin: 6.5.2_4saukclyqastvrycwsozxxbldi
       fs-extra: 9.1.0
       glob: 7.2.3
       handlebars: 4.7.7
@@ -3416,7 +3603,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.8.4
+      typescript: 4.9.3
       util-deprecate: 1.0.2
       webpack: 4.46.0
     transitivePeerDependencies:
@@ -3427,7 +3614,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core-common/6.5.12_zvdcumho7mqj3lfknr2wnpofbm:
+  /@storybook/core-common/6.5.12_lpaunfundvhsawddnxa2u6vj2i:
     resolution: {integrity: sha512-gG20+eYdIhwQNu6Xs805FLrOCWtkoc8Rt8gJiRt8yXzZh9EZkU4xgCRoCxrrJ03ys/gTiCFbBOfRi749uM3z4w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3471,7 +3658,7 @@ packages:
       express: 4.18.2
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_lasgyenclx45ngbljrbo537mpe
+      fork-ts-checker-webpack-plugin: 6.5.2_4saukclyqastvrycwsozxxbldi
       fs-extra: 9.1.0
       glob: 7.2.3
       handlebars: 4.7.7
@@ -3487,7 +3674,78 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.8.4
+      typescript: 4.9.3
+      util-deprecate: 1.0.2
+      webpack: 4.46.0
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: true
+
+  /@storybook/core-common/6.5.13_lpaunfundvhsawddnxa2u6vj2i:
+    resolution: {integrity: sha512-+DVZrRsteE9pw0X5MNffkdBgejQnbnL+UOG3qXkE9xxUamQALnuqS/w1BzpHE9WmOHuf7RWMKflyQEW3OLKAJg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.19.6
+      '@babel/plugin-proposal-decorators': 7.19.6_@babel+core@7.19.6
+      '@babel/plugin-proposal-export-default-from': 7.18.10_@babel+core@7.19.6
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.19.6
+      '@babel/plugin-proposal-object-rest-spread': 7.19.4_@babel+core@7.19.6
+      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.19.6
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.19.6
+      '@babel/plugin-proposal-private-property-in-object': 7.18.6_@babel+core@7.19.6
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.19.6
+      '@babel/plugin-transform-arrow-functions': 7.18.6_@babel+core@7.19.6
+      '@babel/plugin-transform-block-scoping': 7.19.4_@babel+core@7.19.6
+      '@babel/plugin-transform-classes': 7.19.0_@babel+core@7.19.6
+      '@babel/plugin-transform-destructuring': 7.19.4_@babel+core@7.19.6
+      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.19.6
+      '@babel/plugin-transform-parameters': 7.18.8_@babel+core@7.19.6
+      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.19.6
+      '@babel/plugin-transform-spread': 7.19.0_@babel+core@7.19.6
+      '@babel/preset-env': 7.19.4_@babel+core@7.19.6
+      '@babel/preset-react': 7.18.6_@babel+core@7.19.6
+      '@babel/preset-typescript': 7.18.6_@babel+core@7.19.6
+      '@babel/register': 7.18.9_@babel+core@7.19.6
+      '@storybook/node-logger': 6.5.13
+      '@storybook/semver': 7.3.2
+      '@types/node': 16.11.68
+      '@types/pretty-hrtime': 1.0.1
+      babel-loader: 8.2.5_q4ydpsrmbqywduja5orgah6fgq
+      babel-plugin-macros: 3.1.0
+      babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.19.6
+      chalk: 4.1.2
+      core-js: 3.25.5
+      express: 4.18.2
+      file-system-cache: 1.1.0
+      find-up: 5.0.0
+      fork-ts-checker-webpack-plugin: 6.5.2_4saukclyqastvrycwsozxxbldi
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      handlebars: 4.7.7
+      interpret: 2.2.0
+      json5: 2.2.1
+      lazy-universal-dotenv: 3.0.1
+      picomatch: 2.3.1
+      pkg-dir: 5.0.0
+      pretty-hrtime: 1.0.3
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      resolve-from: 5.0.0
+      slash: 3.0.0
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      typescript: 4.9.3
       util-deprecate: 1.0.2
       webpack: 4.46.0
     transitivePeerDependencies:
@@ -3516,7 +3774,13 @@ packages:
       core-js: 3.25.5
     dev: true
 
-  /@storybook/core-server/6.5.10_6wmjcm4t5bjagjtati4r5rwvzq:
+  /@storybook/core-events/6.5.13:
+    resolution: {integrity: sha512-kL745tPpRKejzHToA3/CoBNbI+NPRVk186vGxXBmk95OEg0TlwgQExP8BnqEtLlRZMbW08e4+6kilc1M1M4N5w==}
+    dependencies:
+      core-js: 3.25.5
+    dev: true
+
+  /@storybook/core-server/6.5.10_kn3fje3rno3m32opasdjddbewa:
     resolution: {integrity: sha512-jqwpA0ccA8X5ck4esWBid04+cEIVqirdAcqJeNb9IZAD+bRreO4Im8ilzr7jc5AmQ9fkqHs2NByFKh9TITp8NQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -3533,18 +3797,19 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
-      '@storybook/core-client': 6.5.10_vvswzvegta47ikremfl73qk64u
-      '@storybook/core-common': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/builder-webpack4': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
+      '@storybook/builder-webpack5': 6.5.13_lpaunfundvhsawddnxa2u6vj2i
+      '@storybook/core-client': 6.5.10_5rrtmghzrfkli2obki6uk67fly
+      '@storybook/core-common': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/core-events': 6.5.10
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.10
-      '@storybook/manager-webpack4': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
-      '@storybook/manager-webpack5': 6.5.12_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/manager-webpack4': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
+      '@storybook/manager-webpack5': 6.5.12_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/node-logger': 6.5.10
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/telemetry': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/telemetry': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
       '@types/node': 16.11.68
       '@types/node-fetch': 2.6.2
       '@types/pretty-hrtime': 1.0.1
@@ -3575,7 +3840,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.8.4
+      typescript: 4.9.3
       util-deprecate: 1.0.2
       watchpack: 2.4.0
       webpack: 4.46.0
@@ -3594,7 +3859,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.5.10_uqtyzneeudcfmmjorcoxo4kotu:
+  /@storybook/core/6.5.10_oqlzm5bgprcyy7hdmsd7yzvm34:
     resolution: {integrity: sha512-K86yYa0tYlMxADlwQTculYvPROokQau09SCVqpsLg3wJCTvYFL4+SIqcYoyBSbFmHOdnYbJgPydjN33MYLiOZQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -3611,12 +3876,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.5.10_plmdyubmb7xm6euvqu3qohl7ea
-      '@storybook/core-server': 6.5.10_6wmjcm4t5bjagjtati4r5rwvzq
-      '@storybook/manager-webpack5': 6.5.12_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/builder-webpack5': 6.5.13_lpaunfundvhsawddnxa2u6vj2i
+      '@storybook/core-client': 6.5.10_zmcfsz5vzopt24dcvkwti4umve
+      '@storybook/core-server': 6.5.10_kn3fje3rno3m32opasdjddbewa
+      '@storybook/manager-webpack5': 6.5.12_lpaunfundvhsawddnxa2u6vj2i
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
-      typescript: 4.8.4
+      typescript: 4.9.3
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
@@ -3685,7 +3951,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/manager-webpack4/6.5.10_zvdcumho7mqj3lfknr2wnpofbm:
+  /@storybook/manager-webpack4/6.5.10_lpaunfundvhsawddnxa2u6vj2i:
     resolution: {integrity: sha512-N/TlNDhuhARuFipR/ZJ/xEVESz23iIbCsZ4VNehLHm8PpiGlQUehk+jMjWmz5XV0bJItwjRclY+CU3GjZKblfQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3699,8 +3965,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.19.6
       '@babel/preset-react': 7.18.6_@babel+core@7.19.6
       '@storybook/addons': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-client': 6.5.10_vvswzvegta47ikremfl73qk64u
-      '@storybook/core-common': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/core-client': 6.5.10_5rrtmghzrfkli2obki6uk67fly
+      '@storybook/core-common': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/node-logger': 6.5.10
       '@storybook/theming': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/ui': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
@@ -3717,7 +3983,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4_typescript@4.8.4
+      pnp-webpack-plugin: 1.6.4_typescript@4.9.3
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
       read-pkg-up: 7.0.1
@@ -3727,7 +3993,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.8.4
+      typescript: 4.9.3
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -3743,7 +4009,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/manager-webpack5/6.5.12_zvdcumho7mqj3lfknr2wnpofbm:
+  /@storybook/manager-webpack5/6.5.12_lpaunfundvhsawddnxa2u6vj2i:
     resolution: {integrity: sha512-F+KgoINhfo1ArbirCc9L+EyADYD8Z4t0LyZYDVcBiZ8DlRIMIoUSye6tDsnyEm+OPloLVAcGwRMYgFhuHB70Lg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3757,8 +4023,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.19.6
       '@babel/preset-react': 7.18.6_@babel+core@7.19.6
       '@storybook/addons': 6.5.12_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-client': 6.5.12_plmdyubmb7xm6euvqu3qohl7ea
-      '@storybook/core-common': 6.5.12_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/core-client': 6.5.12_zmcfsz5vzopt24dcvkwti4umve
+      '@storybook/core-common': 6.5.12_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/node-logger': 6.5.12
       '@storybook/theming': 6.5.12_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/ui': 6.5.12_wcqkhtmu7mswc6yz4uyexck3ty
@@ -3783,7 +4049,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 5.3.6_webpack@5.74.0
       ts-dedent: 2.2.0
-      typescript: 4.8.4
+      typescript: 4.9.3
       util-deprecate: 1.0.2
       webpack: 5.74.0
       webpack-dev-middleware: 4.3.0_webpack@5.74.0
@@ -3831,6 +4097,16 @@ packages:
 
   /@storybook/node-logger/6.5.12:
     resolution: {integrity: sha512-jdLtT3mX5GQKa+0LuX0q0sprKxtCGf6HdXlKZGD5FEuz4MgJUGaaiN0Hgi+U7Z4tVNOtSoIbYBYXHqfUgJrVZw==}
+    dependencies:
+      '@types/npmlog': 4.1.4
+      chalk: 4.1.2
+      core-js: 3.25.5
+      npmlog: 5.0.1
+      pretty-hrtime: 1.0.3
+    dev: true
+
+  /@storybook/node-logger/6.5.13:
+    resolution: {integrity: sha512-/r5aVZAqZRoy5FyNk/G4pj7yKJd3lJfPbAaOHVROv2IF7PJP/vtRaDkcfh0g2U6zwuDxGIqSn80j+qoEli9m5A==}
     dependencies:
       '@types/npmlog': 4.1.4
       chalk: 4.1.2
@@ -3891,7 +4167,33 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_qqxisngxjbp7lstdk7boexbu3e:
+  /@storybook/preview-web/6.5.13_wcqkhtmu7mswc6yz4uyexck3ty:
+    resolution: {integrity: sha512-GNNYVzw4SmRua3dOc52Ye6Us4iQbq5GKQ56U3iwnzZM3TBdJB+Rft94Fn1/pypHujEHS8hl5Xgp9td6C1lLCow==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/addons': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/channel-postmessage': 6.5.13
+      '@storybook/client-logger': 6.5.13
+      '@storybook/core-events': 6.5.13
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/store': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      ansi-to-html: 0.6.15
+      core-js: 3.25.5
+      global: 4.4.0
+      lodash: 4.17.21
+      qs: 6.11.0
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      regenerator-runtime: 0.13.10
+      synchronous-promise: 2.0.16
+      ts-dedent: 2.2.0
+      unfetch: 4.2.0
+      util-deprecate: 1.0.2
+    dev: true
+
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_ioost42n2pkm3q6vbnx4ypyu7a:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -3902,15 +4204,15 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2_typescript@4.8.4
+      react-docgen-typescript: 2.2.2_typescript@4.9.3
       tslib: 2.4.0
-      typescript: 4.8.4
+      typescript: 4.9.3
       webpack: 5.74.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/react/6.5.10_crqyzl53zvoogn5jtj5fo5ztaq:
+  /@storybook/react/6.5.10_dnbb5qcebrpunavuaqymrwxhmu:
     resolution: {integrity: sha512-m8S1qQrwA7pDGwdKEvL6LV3YKvSzVUY297Fq+xcTU3irnAy4sHDuFoLqV6Mi1510mErK1r8+rf+0R5rEXB219g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -3943,14 +4245,15 @@ packages:
       '@babel/preset-react': 7.18.6_@babel+core@7.19.6
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.8_metx475lqcp4j5c75za4zf7xbi
       '@storybook/addons': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/builder-webpack5': 6.5.13_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/client-logger': 6.5.10
-      '@storybook/core': 6.5.10_uqtyzneeudcfmmjorcoxo4kotu
-      '@storybook/core-common': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/core': 6.5.10_oqlzm5bgprcyy7hdmsd7yzvm34
+      '@storybook/core-common': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/manager-webpack5': 6.5.12_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/manager-webpack5': 6.5.12_lpaunfundvhsawddnxa2u6vj2i
       '@storybook/node-logger': 6.5.10
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_qqxisngxjbp7lstdk7boexbu3e
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_ioost42n2pkm3q6vbnx4ypyu7a
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.10_wcqkhtmu7mswc6yz4uyexck3ty
       '@types/estree': 0.0.51
@@ -3976,7 +4279,7 @@ packages:
       regenerator-runtime: 0.13.10
       require-from-string: 2.0.2
       ts-dedent: 2.2.0
-      typescript: 4.8.4
+      typescript: 4.9.3
       util-deprecate: 1.0.2
       webpack: 5.74.0
     transitivePeerDependencies:
@@ -4050,6 +4353,21 @@ packages:
       regenerator-runtime: 0.13.10
     dev: true
 
+  /@storybook/router/6.5.13_wcqkhtmu7mswc6yz4uyexck3ty:
+    resolution: {integrity: sha512-sf5aogfirH5ucD0d0hc2mKf2iyWsZsvXhr5kjxUQmgkcoflkGUWhc34sbSQVRQ1i8K5lkLIDH/q2s1Zr2SbzhQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 6.5.13
+      core-js: 3.25.5
+      memoizerific: 1.11.3
+      qs: 6.11.0
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      regenerator-runtime: 0.13.10
+    dev: true
+
   /@storybook/semver/7.3.2:
     resolution: {integrity: sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==}
     engines: {node: '>=10'}
@@ -4109,11 +4427,36 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/telemetry/6.5.10_zvdcumho7mqj3lfknr2wnpofbm:
+  /@storybook/store/6.5.13_wcqkhtmu7mswc6yz4uyexck3ty:
+    resolution: {integrity: sha512-GG6lm+8fBX1tNUnX7x3raBOjYhhf14bPWLtYiPlxDTFEMs3sJte7zWKZq6NQ79MoBLL6jjzTeolBfDCBw6fiWQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/addons': 6.5.13_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/client-logger': 6.5.13
+      '@storybook/core-events': 6.5.13
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      core-js: 3.25.5
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      regenerator-runtime: 0.13.10
+      slash: 3.0.0
+      stable: 0.1.8
+      synchronous-promise: 2.0.16
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: true
+
+  /@storybook/telemetry/6.5.10_lpaunfundvhsawddnxa2u6vj2i:
     resolution: {integrity: sha512-+M5HILDFS8nDumLxeSeAwi1MTzIuV6UWzV4yB2wcsEXOBTdplcl9oYqFKtlst78oOIdGtpPYxYfivDlqxC2K4g==}
     dependencies:
       '@storybook/client-logger': 6.5.10
-      '@storybook/core-common': 6.5.10_zvdcumho7mqj3lfknr2wnpofbm
+      '@storybook/core-common': 6.5.10_lpaunfundvhsawddnxa2u6vj2i
       chalk: 4.1.2
       core-js: 3.25.5
       detect-package-manager: 2.0.1
@@ -4179,6 +4522,20 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@storybook/client-logger': 6.5.12
+      core-js: 3.25.5
+      memoizerific: 1.11.3
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      regenerator-runtime: 0.13.10
+    dev: true
+
+  /@storybook/theming/6.5.13_wcqkhtmu7mswc6yz4uyexck3ty:
+    resolution: {integrity: sha512-oif5NGFAUQhizo50r+ctw2hZNLWV4dPHai+L/gFvbaSeRBeHSNkIcMoZ2FlrO566HdGZTDutYXcR+xus8rI28g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 6.5.13
       core-js: 3.25.5
       memoizerific: 1.11.3
       react: 16.14.0
@@ -5535,6 +5892,10 @@ packages:
       resolve: 1.22.1
     dev: true
 
+  /babel-plugin-named-exports-order/0.0.2:
+    resolution: {integrity: sha512-OgOYHOLoRK+/mvXU9imKHlG6GkPLYrUCvFXG/CM93R/aNNO8pOOF4aS+S8CCHMDQoNSeiOYEZb/G6RwL95Jktw==}
+    dev: true
+
   /babel-plugin-polyfill-corejs2/0.3.3_@babel+core@7.19.6:
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
@@ -5808,6 +6169,10 @@ packages:
 
   /brorand/1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+    dev: true
+
+  /browser-assert/1.2.1:
+    resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
     dev: true
 
   /browser-process-hrtime/1.0.0:
@@ -8372,7 +8737,7 @@ packages:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: false
 
-  /fork-ts-checker-webpack-plugin/4.1.6_lasgyenclx45ngbljrbo537mpe:
+  /fork-ts-checker-webpack-plugin/4.1.6_4saukclyqastvrycwsozxxbldi:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -8392,14 +8757,14 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.8.4
+      typescript: 4.9.3
       webpack: 4.46.0
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.2_lasgyenclx45ngbljrbo537mpe:
+  /fork-ts-checker-webpack-plugin/6.5.2_4saukclyqastvrycwsozxxbldi:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -8426,8 +8791,39 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.8
       tapable: 1.1.3
-      typescript: 4.8.4
+      typescript: 4.9.3
       webpack: 4.46.0
+    dev: true
+
+  /fork-ts-checker-webpack-plugin/6.5.2_ioost42n2pkm3q6vbnx4ypyu7a:
+    resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
+    engines: {node: '>=10', yarn: '>=1.0.0'}
+    peerDependencies:
+      eslint: '>= 6'
+      typescript: '>= 2.7'
+      vue-template-compiler: '*'
+      webpack: '>= 4'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      vue-template-compiler:
+        optional: true
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@types/json-schema': 7.0.11
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      cosmiconfig: 6.0.0
+      deepmerge: 4.2.2
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      memfs: 3.4.7
+      minimatch: 3.1.2
+      schema-utils: 2.7.0
+      semver: 7.3.8
+      tapable: 1.1.3
+      typescript: 4.9.3
+      webpack: 5.74.0
     dev: true
 
   /form-data/2.3.3:
@@ -12247,6 +12643,10 @@ packages:
     resolution: {integrity: sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==}
     dev: true
 
+  /path-browserify/1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: true
+
   /path-dirname/1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
     dev: true
@@ -12409,11 +12809,11 @@ packages:
       find-up: 2.1.0
     dev: true
 
-  /pnp-webpack-plugin/1.6.4_typescript@4.8.4:
+  /pnp-webpack-plugin/1.6.4_typescript@4.9.3:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.8.4
+      ts-pnp: 1.2.0_typescript@4.9.3
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -12958,12 +13358,12 @@ packages:
       react: 16.14.0
     dev: true
 
-  /react-docgen-typescript/2.2.2_typescript@4.8.4:
+  /react-docgen-typescript/2.2.2_typescript@4.9.3:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 4.8.4
+      typescript: 4.9.3
     dev: true
 
   /react-docgen/5.4.3:
@@ -14938,7 +15338,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/27.1.5_wllvn5ev7s34rczlryjnunwcxu:
+  /ts-jest/27.1.5_hkzu5mxcd5jsil5nsffofi7n7u:
     resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -14970,11 +15370,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.8
-      typescript: 4.8.4
+      typescript: 4.9.3
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-pnp/1.2.0_typescript@4.8.4:
+  /ts-pnp/1.2.0_typescript@4.9.3:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -14983,13 +15383,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.8.4
+      typescript: 4.9.3
     dev: true
 
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
-  /tsup/6.3.0_typescript@4.8.4:
+  /tsup/6.3.0_typescript@4.9.3:
     resolution: {integrity: sha512-IaNQO/o1rFgadLhNonVKNCT2cks+vvnWX3DnL8sB87lBDqRvJXHENr5lSPJlqwplUlDxSwZK8dSg87rgBu6Emw==}
     engines: {node: '>=14'}
     hasBin: true
@@ -15019,7 +15419,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.28.0
       tree-kill: 1.2.2
-      typescript: 4.8.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -15165,6 +15565,12 @@ packages:
 
   /typescript/4.8.4:
     resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript/4.9.3:
+    resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Currently using a custom component you have to work through the type errors in `Board` until you have added all the mandatory props.

This PR exposes a type helper for each custom component which is optionally generic, allowing you to easily define the type for your custom component and also specify any custom props for full prop inference.

Example:
```ts
type CustomCardProps = {
  	dueOn: string;
  }
 
  const CustomCard: CardComponent<CustomCardProps> = ({ dueOn, ...props }) => {
  	return (
  		<Card {...props}>
  			<Detail>{dueOn}</Detail>
  		</Card>
  	)
  }
 ```