### PR TITLE
Bug fix: Card returns to previous lane

### DIFF
--- a/packages/react-trello-ts/src/controllers/Lane.tsx
+++ b/packages/react-trello-ts/src/controllers/Lane.tsx
@@ -144,19 +144,15 @@ export const Lane: FC<PropsWithChildren<LaneProps>> = ({
 		setAddCardMode(false);
 		const card = { id: _id, ...params };
 		board.addCard(card, laneId);
-		onCardAdd(card, laneId);
+		onCardAdd?.(card, laneId);
 	};
 	const updateCard = (updatedCard: Card) => {
 		board.updateCard(id, updatedCard);
-		onCardUpdate(id, updatedCard);
+		onCardUpdate?.(id, updatedCard);
 	};
 	const updateTitle = (value) => {
 		board.updateLane({ id, title: value });
-		onLaneUpdate(id, { id, title: value });
-		onLaneUpdate(id, {
-			title: value,
-			id: id,
-		});
+		onLaneUpdate?.(id, { id, title: value });
 	};
 	const laneDidMount = (node: HTMLDivElement) => {
 		if (node) {
@@ -165,7 +161,7 @@ export const Lane: FC<PropsWithChildren<LaneProps>> = ({
 	};
 	const removeLane = () => {
 		board.removeLane(id);
-		onLaneDelete(id);
+		onLaneDelete?.(id);
 	};
 	const handleScroll = (evt) => {
 		const node = evt.target;
@@ -194,12 +190,12 @@ export const Lane: FC<PropsWithChildren<LaneProps>> = ({
 	const removeCard = (cardId: Card["id"]) => {
 		if (onBeforeCardDelete && typeof onBeforeCardDelete === "function") {
 			onBeforeCardDelete(() => {
-				onCardDelete?.(cardId, id);
 				board.removeCard(id, cardId);
+				onCardDelete?.(cardId, id);
 			});
 		} else {
-			onCardDelete?.(cardId, id);
 			board.removeCard(id, cardId);
+			onCardDelete?.(cardId, id);
 		}
 	};
 	const onDragStart = ({ payload }) => {
@@ -224,7 +220,7 @@ export const Lane: FC<PropsWithChildren<LaneProps>> = ({
 				: true;
 			if (response === undefined || !!response) {
 				board.moveCard(payload.laneId, laneId, payload.id, addedIndex);
-				onCardMoveAcrossLanes(payload.laneId, laneId, payload.id, addedIndex);
+				onCardMoveAcrossLanes?.(payload.laneId, laneId, payload.id, addedIndex);
 			}
 			return response;
 		}

--- a/packages/react-trello-ts/src/store/store.ts
+++ b/packages/react-trello-ts/src/store/store.ts
@@ -1,6 +1,7 @@
 import produce from "immer";
 import { BoardData, Card, Lane } from "../types/Board";
 import create from "zustand";
+import cloneDeep from "lodash/cloneDeep";
 
 export interface State {
 	data: BoardData;
@@ -75,12 +76,13 @@ export const store = create<State>()((set) => ({
 				const cardIndex = fromLane.cards.findIndex((c) => c.id === cardId);
 				if (cardIndex !== -1) {
 					const card = fromLane.cards[cardIndex];
+					const newCard = { ...cloneDeep(card), laneId: toLaneId };
 					fromLane.cards.splice(cardIndex, 1);
 					if (index !== undefined) {
-						toLane.cards.splice(index, 0, card);
+						toLane.cards.splice(index, 0, newCard);
 						return;
 					}
-					toLane.cards.push(card);
+					toLane.cards.push(newCard);
 				}
 			}),
 		),

--- a/packages/react-trello-ts/src/store/store.ts
+++ b/packages/react-trello-ts/src/store/store.ts
@@ -46,6 +46,10 @@ export const store = create<State>()((set) => ({
 				if (!lane) {
 					throw new Error("Lane not found");
 				}
+				if (index === undefined && lane.cards) {
+					lane.cards.push(card);
+					return;
+				}
 				lane.cards[index || 0] = card;
 			}),
 		),


### PR DESCRIPTION
Fixed bugs:
1. After first successful card lane change, subsequent card lane changes don't work.
2. New card replaces existing cards

Changes:
Callback methods order updated. Action happens first before callback is called
