### PR TITLE
Remove classnames

### DIFF
--- a/packages/react-trello-ts/.gitignore
+++ b/packages/react-trello-ts/.gitignore
@@ -7,3 +7,4 @@ dist/
 .history/
 storybook-build
 .npmrc
+coverage

--- a/packages/react-trello-ts/package.json
+++ b/packages/react-trello-ts/package.json
@@ -36,7 +36,6 @@
   "homepage": "https://github.com/KaiSpencer/react-trello-ts",
   "dependencies": {
     "autosize": "^4.0.2",
-    "classnames": "^2.2.6",
     "immer": "^9.0.15",
     "immutability-helper": "^2.8.1",
     "lodash": "^4.17.11",

--- a/packages/react-trello-ts/src/controllers/Board.tsx
+++ b/packages/react-trello-ts/src/controllers/Board.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, FC, PropsWithChildren } from "react";
-import classNames from "classnames";
 import { v1 } from "uuid";
 import { BoardContainer } from "./BoardContainer";
 import * as DefaultComponets from "../components";
@@ -15,7 +14,7 @@ export const Board: FC<
 		t?: any;
 	}>
 > = ({ data, children, className, components, id, t, ...rest }) => {
-	const allClassNames = classNames("react-trello-board", className || "");
+	const allClassNames = className ? `react-trello-board ${className}` : "react-trello-board";
 
 	return (
 		<BoardContext.Provider value={store}>

--- a/packages/react-trello-ts/src/controllers/Lane.tsx
+++ b/packages/react-trello-ts/src/controllers/Lane.tsx
@@ -1,5 +1,4 @@
 import React, { CSSProperties, FC, PropsWithChildren, useEffect } from "react";
-import classNames from "classnames";
 import cloneDeep from "lodash/cloneDeep";
 import { v1 } from "uuid";
 
@@ -300,7 +299,7 @@ export const Lane: FC<PropsWithChildren<LaneProps>> = ({
 		);
 	};
 
-	const allClassNames = classNames("react-trello-lane", className || "");
+	const allClassNames = className? `react-trello-lane ${className}` : "react-trello-lane";
 	const showFooter = collapsibleLanes && cards.length > 0;
 	return (
 		<components.Section

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,6 @@ importers:
       babel-jest: ^27
       babel-plugin-module-resolver: ^3.2.0
       babel-plugin-require-context-hook: ^1.0.0
-      classnames: ^2.2.6
       gh-pages: ^4.0.0
       i18next: ^17.0.3
       identity-obj-proxy: ^3.0.0
@@ -128,11 +127,10 @@ importers:
       zustand: ^4.1.1
     dependencies:
       autosize: 4.0.4
-      classnames: 2.3.2
       immer: 9.0.15
       immutability-helper: 2.9.1
       lodash: 4.17.21
-      react-popopo: 2.1.9_7wdodx5nsa5yg5y3zejnac65wm
+      react-popopo: 2.1.9_4xwksyvg4vpbe27uccj6v2hnbe
       trello-smooth-dnd: 1.0.0
       uuid: 9.0.0
       zustand: 4.1.2_immer@9.0.15+react@16.14.0
@@ -15922,10 +15920,9 @@ packages:
       webpack: 5.74.0
     dev: false
 
-  /react-popopo/2.1.9_7wdodx5nsa5yg5y3zejnac65wm:
+  /react-popopo/2.1.9_4xwksyvg4vpbe27uccj6v2hnbe:
     resolution: {integrity: sha512-zXOpcLSpaLZmBxhdtenJzQPLjY81XknVS/tXH4Kv5BBrnYIUPHvVdGmS7+o9s7DjCzzdK7AdVwtG+FVSO0cZ8g==}
     peerDependencies:
-      classnames: '>= 2.0'
       react: '>= 16.3'
       react-dom: '>= 16.3'
       styled-components: '>= 4.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,11 +102,9 @@ importers:
       i18next: ^17.0.3
       identity-obj-proxy: ^3.0.0
       immer: ^9.0.15
-      immutability-helper: ^2.8.1
       jest: ^27
       jest-cli: ^27
       jest-styled-components: ^7
-      lodash: ^4.17.11
       preact: '>=10.5.13 <11.0.0'
       prettier: 1.14.3
       react: ^16
@@ -128,8 +126,6 @@ importers:
     dependencies:
       autosize: 4.0.4
       immer: 9.0.15
-      immutability-helper: 2.9.1
-      lodash: 4.17.21
       react-popopo: 2.1.9_4xwksyvg4vpbe27uccj6v2hnbe
       trello-smooth-dnd: 1.0.0
       uuid: 9.0.0
@@ -11610,12 +11606,6 @@ packages:
 
   /immer/9.0.15:
     resolution: {integrity: sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==}
-    dev: false
-
-  /immutability-helper/2.9.1:
-    resolution: {integrity: sha512-r/RmRG8xO06s/k+PIaif2r5rGc3j4Yhc01jSBfwPCXDLYZwp/yxralI37Df1mwmuzcCsen/E/ITKcTEvc1PQmQ==}
-    dependencies:
-      invariant: 2.2.4
     dev: false
 
   /import-fresh/3.3.0:


### PR DESCRIPTION
Only used in two places for a very simple string concat. Removed to reduce bundle size